### PR TITLE
Fixed constructor_standings(year, race) bug

### DIFF
--- a/pyergast/pyergast.py
+++ b/pyergast/pyergast.py
@@ -706,7 +706,7 @@ def constructor_standings(year=None, race=None):
     """
     if year and race:
         assert year >= 1958, 'Constructor standings only available starting 1958'
-        url = 'http://ergast.com/api/f1/{}/constructorStandings.json?limit=1000'.format(year, race)
+        url = 'http://ergast.com/api/f1/{}/{}/constructorStandings.json?limit=1000'.format(year, race)
     elif year:
         assert year >= 1958, 'Constructor standings only available starting 1958'
         url = 'http://ergast.com/api/f1/{}/constructorStandings.json?limit=1000'.format(year, race)


### PR DESCRIPTION
Fixes issue #1

The `constructor_standings` request to the pyErgast API was only returning the year's final standings, not each race's. Now the url matches the equivalent one for `driver_standings`.